### PR TITLE
Remove leftover Celo cUSD references after Base migration.

### DIFF
--- a/Server/.env.example
+++ b/Server/.env.example
@@ -10,7 +10,7 @@ JWT_SECRET=your-jwt-secret-here
 # Alchemy Webhook Configuration
 ALCHEMY_WEBHOOK_SIGNING_KEY=your-alchemy-webhook-signing-key
 ALCHEMY_API_KEY=your-alchemy-api-key
-USDC_CONTRACT_ADDRESS=0xcebA9300f2b948710d2653dD7B07f33A8B32118C
+USDC_CONTRACT_ADDRESS=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
 
 # Coinbase Developer Platform Paymaster + Bundler (Base mainnet) — required for EIP-7702 txs
 COINBASE_PAYMASTER_URL=https://api.developer.coinbase.com/rpc/v1/base/your-api-key

--- a/Server/Blockchain/ReadFunctions.ts
+++ b/Server/Blockchain/ReadFunctions.ts
@@ -1,7 +1,7 @@
 // this file contains all the blockchain read functions
 import { createPublicClient, http } from 'viem'
-import { celo, base } from 'viem/chains'
-import { cUSDAddress, contractABI, USDCAddress, contractAddress } from './Constants'
+import { base } from 'viem/chains'
+import { contractABI, USDCAddress, contractAddress } from './Constants'
 import { erc20Abi } from 'viem'
  
 const publicClient = createPublicClient({
@@ -9,26 +9,7 @@ const publicClient = createPublicClient({
   transport: http()
 })
 
-// getting cUSD and USDC balance
-export const getTokenBalance = async (address: string) => {
-    const [cUSDBalance, USDCBalance] = await Promise.all([
-        publicClient.readContract({
-            address: cUSDAddress,
-            abi: erc20Abi,
-            functionName: 'balanceOf',
-            args: [address as `0x${string}`]
-        }),
-        publicClient.readContract({
-            address: USDCAddress,
-            abi: erc20Abi,
-            functionName: 'balanceOf',
-            args: [address as `0x${string}`]
-        }),
-    ]);
-    return { cUSDBalance, USDCBalance };
-}
-
-// function to get a user's balance
+// function to get a user's chama balance
 export const getUserChamaBalance = async (memberAddress: string, chamaBlockchainId: bigint) => {
     const balance = await publicClient.readContract({
         address: contractAddress,

--- a/Server/Lib/Thirdweb.ts
+++ b/Server/Lib/Thirdweb.ts
@@ -18,7 +18,6 @@ import { erc20Abi } from "viem";
 import {
   contractABI,
   contractAddress,
-  cUSDAddress,
 } from "../Blockchain/Constants";
 
 configDotenv();


### PR DESCRIPTION
Drop cUSDAddress imports and dual-token balance reads so the server build only uses Base USDC.